### PR TITLE
Start hot reloading via command instead of config

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -43,4 +43,4 @@ if (production === true) {
 }
 
 // Run in development mode…
-shell.exec('webpack-dev-server');
+shell.exec('webpack-dev-server --hot --inline');

--- a/src/options/devServer.js
+++ b/src/options/devServer.js
@@ -15,11 +15,6 @@ module.exports = (options = {}) => ({
     // @see https://webpack.js.org/configuration/dev-server/#devserver-contentbase
     contentBase: delve(options, 'contentBase', defaults.contentBase),
 
-    // @see https://webpack.js.org/configuration/dev-server/#devserver-hot
-    // @see https://webpack.js.org/concepts/hot-module-replacement/
-    // @see https://webpack.js.org/guides/hot-module-replacement/
-    hot: delve(options, 'hot', defaults.hot),
-
     // @see https://webpack.js.org/configuration/dev-server/#devserver-open
     open: delve(options, 'open', defaults.open),
 

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -1,6 +1,5 @@
 const clean = require('./plugins/clean');
 const friendlyErrors = require('./plugins/friendlyErrors');
-const hmr = require('./plugins/hmr');
 const html = require('./plugins/html');
 const miniCssExtract = require('./plugins/miniCssExtract');
 const writeFile = require('./plugins/writeFile');
@@ -8,7 +7,6 @@ const writeFile = require('./plugins/writeFile');
 module.exports = {
     clean,
     friendlyErrors,
-    hmr,
     html,
     miniCssExtract,
     writeFile

--- a/src/plugins/hmr.js
+++ b/src/plugins/hmr.js
@@ -1,4 +1,0 @@
-const webpack = require('webpack');
-
-// @see https://webpack.js.org/plugins/hot-module-replacement-plugin/
-module.exports = (options = {}) => new webpack.HotModuleReplacementPlugin(options);

--- a/src/presets/common.js
+++ b/src/presets/common.js
@@ -1,7 +1,7 @@
 const merge = require('webpack-merge');
 const delve = require('dlv');
 
-const { clean, html, hmr, friendlyErrors, writeFile } = require('../plugins');
+const { clean, html, friendlyErrors, writeFile } = require('../plugins');
 const { entry, output, resolve, stats } = require('../options');
 
 const css = require('./css');
@@ -28,8 +28,7 @@ module.exports = (options = {}) => {
                         root: delve(options, 'context')
                     }, options.clean)
                 ),
-                html(options.html), // @todo How to handleeine multiple html files?
-                hmr(options.hmr)
+                html(options.html) // @todo How to handleeine multiple html files?
             ],
 
             // @see https://webpack.js.org/configuration/output/


### PR DESCRIPTION
Remove hmr from plugin list and add **--hot** and **--inline** in the cli when running `webpack-dev-server`

see also: [https://github.com/webpack/webpack/issues/1151#issuecomment-111972680](https://github.com/webpack/webpack/issues/1151#issuecomment-111972680)